### PR TITLE
Guarantee ordering of events and entitites

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -8,6 +8,8 @@ import os
 import string
 from openpyxl import Workbook
 import pdb
+from collections import OrderedDict
+
 
 def writeOutput(files):
     # path = os.getcwd()
@@ -97,11 +99,13 @@ def writeSentence(file, index, writer, eventReader, data, query, query_finder, s
         writer.writeRow('Variables', [str(file), query, sentence, str(scores)])
     lemmas = eventReader.getSentenceLemmas(index)
     pos = eventReader.getSentencePOSTags(index)
-    entLocalIndex = {}
+    entLocalIndex = OrderedDict()
     entities = allEntities[index]
     events = allEvents[index]
-    entityScores={}
-    for span in entities.keys():
+    entityScores= OrderedDict()
+    entities_keys = entities.keys()
+    entities_keys.sort()
+    for span in entities_keys:
         entity = entities[span]
         entIndex = writer.getIndex('Entities')
         entLocalIndex[span] = 'N' + str(entIndex - 1)
@@ -113,10 +117,12 @@ def writeSentence(file, index, writer, eventReader, data, query, query_finder, s
         entInfo = [str(file), query, str(score), 'N' + str(entIndex - 1), string.lower(entity["trigger"]), entity["frame"],
                    str(entity["FrameNetFr"]), str(scores), string.lower(entity['qualifier']), sentence]
         writer.writeRow('Entities', entInfo)
-    eventLocalIndex = {}
-    eventScores={}
+    eventLocalIndex = OrderedDict()
+    eventScores=OrderedDict()
     event2Spans=[]
-    for span in events.keys():
+    events_keys = events.keys()
+    events_keys.sort()
+    for span in events_keys:
         event = events[span]
         if 'event2' in event['frame']:
             event2Spans.append(span)


### PR DESCRIPTION
This pull request contains minor updates to `Main.py` intended to preserve ordering or critical dictionaries when sent for Causality Detection. Also, this includes sorting `keys` of dictionaries prior to iterating through them to preserve `span` ordering as it appears in the text submitted to SOFIA.

Until [Python 3.6](https://docs.python.org/3.6/whatsnew/3.6.html#new-dict-implementation) there was no guarantee of ordering in dictionaries. Python 3.6 and beyond, insertion ordering is guaranteed. Take this example:

```
sample = {}
sample['susan'] = 1
sample['bob'] = 50
sample['jim'] = 100
```

In **Python 2**, if we ask for `sample.keys()` we will be returned keys in arbitrary order. For example this could return `['bob', 'susan', 'jim']`.

In **Python 3** `sample.keys()` will return the keys **in insertion order** which **must be**: `['susan', 'bob', 'jim']`

Since the `key` order is relied on by `CausalityDetection.py`, it is preferable to use `OrderedDict` to ensure compatibility with Python 2 and Python 3.